### PR TITLE
Model_select and predict_phenology tweaks

### DIFF
--- a/R/model_select.R
+++ b/R/model_select.R
@@ -38,10 +38,10 @@ model_select <- function(author,
       author == {{ author }} &
         species == {{ species }} &
         model == {{ model }} &
-        dev.type == {{ dev.type }}
-    ) |>
-    dplyr::pull("func")
-
-  mod <- parse(text = mod)
-  return(mod)
+        dev.type == {{ dev.type }})
+  #   ) |>
+  #   dplyr::pull("func")
+  #
+  # mod <- parse(text = mod)
+  # return(mod)
 }


### PR DESCRIPTION
Suggested edits to model_select so the function returns a data frame with all model info rather than just the expression. Edits to predict_phenology to extract the expression from the model input, which is now a data frame. Also, include model specs in the output list. Changed the returned results when fish did not develop so they can be retained in the same format as model runs where fish do develop, now just has NA values as placeholders in fields where there won't be a value when they fail to develop, e.g. dev.period$stop.